### PR TITLE
Update README API references

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,15 @@ Open [http://localhost:3000](http://localhost:3000) with your browser to see the
 
 You can start editing the page by modifying `pages/index.js`. The page auto-updates as you edit the file.
 
-[API routes](https://nextjs.org/docs/api-routes/introduction) can be accessed on [http://localhost:3000/api/hello](http://localhost:3000/api/hello). This endpoint can be edited in `pages/api/hello.js`.
+[API routes](https://nextjs.org/docs/api-routes/introduction) can be accessed on endpoints such as `/api/mail`, `/api/fetchPosts`, and `/api/refreshToken`. These are defined in the `pages/api` directory.
 
 The `pages/api` directory is mapped to `/api/*`. Files in this directory are treated as [API routes](https://nextjs.org/docs/api-routes/introduction) instead of React pages.
+
+The `pages/api` directory currently includes:
+
+- `fetchPosts.js`
+- `mail.js`
+- `refreshToken.js`
 
 ## Learn More
 


### PR DESCRIPTION
## Summary
- update API routes section in README
- list available endpoints in API directory

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6847fd42c2388331ad2cb2f0d91173bd